### PR TITLE
div_duration stable in 1.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,14 @@
 name = "gcra"
 version = "0.6.0"
 edition = "2021"
+rust-version = "1.80.0"
 authors = ["Sam Shih <lytefast@github.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/lytefast/gcra-rs"
 homepage = "https://github.com/lytefast/gcra-rs"
 description = "A basic implementation of GCRA algorithm for rate limiting"
-keywords = ["rate-limit", "rate", "limit", "gcra"]
+keywords = ["rate-limit", "rate", "limit", "gcra", "rate limit", "limiter"]
 
 [features]
 default = ["rate-limiter"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(div_duration)]
-
 //! Library which implements the core
 //! [GCRA](https://en.wikipedia.org/wiki/Generic_cell_rate_algorithm) functionality in rust.
 //!


### PR DESCRIPTION
- bump the version to `0.6.0` since we now require min rust version.
- 1.80 is, as of now [still in beta](https://releases.rs/docs/1.80.0/) and is planned to be stable 25 July, 2024

https://github.com/lytefast/gcra-rs/issues/8#issuecomment-2189548833