### PR TITLE
rate limiter can use reference for `RateLimit`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "gcra"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcra"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Sam Shih <lytefast@github.com>"]
 license = "MIT"

--- a/examples/rate_limiter.rs
+++ b/examples/rate_limiter.rs
@@ -8,10 +8,10 @@ async fn main() -> Result<(), GcraError> {
     let rate_limit = RateLimit::per_sec(2);
     let rl = RateLimiter::with_shards(CACHE_CAPACITY, WORKER_SHARD_COUNT);
 
-    rl.check("key", rate_limit.clone(), 1).await?;
-    rl.check("key", rate_limit.clone(), 1).await?;
+    rl.check("key", &rate_limit, 1).await?;
+    rl.check("key", &rate_limit, 1).await?;
 
-    match rl.check("key", rate_limit.clone(), 1).await {
+    match rl.check("key", &rate_limit, 1).await {
         Err(GcraError::DeniedUntil { next_allowed_at }) => {
             print!("Denied: Request next at {:?}", next_allowed_at);
             Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,10 @@
 //!     let rate_limit = RateLimit::per_sec(2);
 //!     let rl = RateLimiter::new(4);
 //!
-//!     rl.check("key", rate_limit.clone(), 1).await?;
-//!     rl.check("key", rate_limit.clone(), 1).await?;
+//!     rl.check("key", &rate_limit, 1).await?;
+//!     rl.check("key", &rate_limit, 1).await?;
 //!
-//!     match rl.check("key", rate_limit.clone(), 1).await {
+//!     match rl.check("key", &rate_limit, 1).await {
 //!         Err(GcraError::DeniedUntil { next_allowed_at }) => {
 //!             print!("Denied: Request next at {:?}", next_allowed_at);
 //!             Ok(())


### PR DESCRIPTION
The internal function accepts a ref, and the `RateLimiter` functions don't do anything but pipe the parameter. It's safe to only require a ref here to avoid the clone.